### PR TITLE
Added caching of x509 public keys and toolkit public keys

### DIFF
--- a/src/lib/flarebase-auth.ts
+++ b/src/lib/flarebase-auth.ts
@@ -232,7 +232,13 @@ export class FlarebaseAuth {
   async verifySessionCookie(sessionCookie: string): Promise<DecodedIdToken> {
     //Fetch google public key
     const res = await fetch(
-      'https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys'
+      'https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys',
+      {
+        cf: {
+          cacheTtl: 60 * 60 * 24,
+          cacheEverything: true
+        }
+      }
     );
 
     const header = decodeProtectedHeader(sessionCookie);

--- a/src/lib/flarebase-auth.ts
+++ b/src/lib/flarebase-auth.ts
@@ -264,6 +264,6 @@ export class FlarebaseAuth {
    * @param idToken An Identity Platform ID token
    */
   async verifyIdToken(idToken: string): Promise<DecodedIdToken> {
-    return (await verifyIdToken(idToken)) as any as DecodedIdToken;
+    return (await verifyIdToken(idToken, this.config.cache)) as any as DecodedIdToken;
   }
 }

--- a/src/lib/google-oauth.ts
+++ b/src/lib/google-oauth.ts
@@ -87,7 +87,7 @@ export async function verifyIdToken(idToken: string, cache: Cache | undefined = 
 				const { maxAge, response } = await getTtl(url);
 				data = await response.json();
 
-				await cache.p(key, JSON.stringify(data), {
+				await cache.put(key, JSON.stringify(data), {
 					expirationTtl: maxAge
 				});
 			}


### PR DESCRIPTION
This PR introduces necessary caching mechanism for Cloudflare network.  x509 public keys are now cached using max-age returned from the initial request. And toolkit public keys are cached using Cache API. 

Please note, without such caching eventually Google starts to throttle those fetches and in some cases would result in Auth taking more than 20 seconds. I am having some conversations with Firebase staff about it but it seems that Google just doesn't like CF network frequently fetching the keys. 
